### PR TITLE
Merge steps 4&5 of the process into a single step

### DIFF
--- a/documents/the-process.md
+++ b/documents/the-process.md
@@ -95,16 +95,8 @@ Inside Google Drive Folder "*Section*: Sections Planning (CL)", create:
             - Create an "input task"[3] in asana
             - When all conversations are resolved, Create Hifi wireframe!
 
-        4. Inside "User Flow Pieces" folder, create Hifi wireframe
+        4. Inside "x. *Use Case* < *Section* (CL)" folder, create a User Flow Diagram
             - Create Hifi wireframe using Adobe XD
-            - Inside "user flow folder"[2] , create a google drawing to get input on wireframe
-                - Add title: "Hifi wireframe < User Flow Pieces < x. *Use Case* <  *Section* (CL)"
-            - Export any screens created in XD and upload them to google drawing doc
-            - Add any helpful comments, e.g reasoning for design decisions, specific questions about design
-            - Create an "input task"[3] in asana
-            - When all conversations are resolved, Create User Flow Diagram!
-
-        5. Inside "x. *Use Case* < *Section* (CL)" folder, create a User Flow Diagram
             - Create a google presentation file
               - Add title: "User Flow Presentation < x. *Use Case* < *Section* (CL)"
             - Export any screens created in XD and add them to a slide in the google presentation


### PR DESCRIPTION
Just a proposal - I think removing the extra step (the PR merges step 4&5 into one, so the send-to-last step of the User Flow creation is combined with the last, ie. we create a hifi XD doc and then create the UserFlow and get input on that, so it really just removes the step of getting input on the hifi diagram).  My thinking is that the value lost from removing the extra step is small and so is outweighed by the benefit of not having the extra input session in terms of time and context switching.  

What do you guys think? 